### PR TITLE
Fixed url selection logic

### DIFF
--- a/BoomV5S3Zero.ino
+++ b/BoomV5S3Zero.ino
@@ -221,7 +221,7 @@ void setup() {
     touchAttachInterrupt(TOUCHDOWN, VolumeDown, TOUCHTHRESS); 
     touchAttachInterrupt(TOUCHUP, VolumeUp, TOUCHTHRESS);       // Init touch interrupts
     Serial.println("Connecting to stream");
-    if (url = "URL1"){
+    if (url == "URL1"){
         audio.connecttohost(URL1);    // Radio Seara 1027 AAC Stream
     } else {
         audio.connecttohost(URL2);    // Radio Seara 1047 AAC Stream


### PR DESCRIPTION
Looking over the code...

shouldn't `if (url = "URL1")` have a camparitor `==` not assignment `'`

``` C++
   Serial.println("Connecting to stream");
    if (url = "URL1"){
        audio.connecttohost(URL1);    // Radio Seara 1027 AAC Stream
    } else {
        audio.connecttohost(URL2);    // Radio Seara 1047 AAC Stream
    }
}
```